### PR TITLE
Fix code scanning alert no. 6: Reflected server-side cross-site scripting

### DIFF
--- a/src/vulnpy/aiohttp/vulnerable_routes.py
+++ b/src/vulnpy/aiohttp/vulnerable_routes.py
@@ -1,7 +1,7 @@
 from aiohttp import web
 from vulnpy.common import get_template
 from vulnpy.trigger import TRIGGER_MAP, get_trigger
-
+import html
 
 def _get_user_input(request):
     return request.rel_url.query.get("user_input", "")
@@ -26,7 +26,7 @@ def get_trigger_view(name, trigger):
         template = get_template("{}.html".format(name))
 
         if name == "xss" and trigger == "raw":
-            template += "<p>XSS: " + user_input + "</p>"
+            template += "<p>XSS: " + html.escape(user_input) + "</p>"
 
         return web.Response(text=template, content_type="text/html")
 


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Python_1/security/code-scanning/6](https://github.com/Brook-5686/Python_1/security/code-scanning/6)

To fix the reflected cross-site scripting vulnerability, we need to ensure that any user input included in the HTML response is properly escaped. This can be achieved by using the `html.escape()` function from Python's standard library, which converts special characters (e.g., `<`, `>`, `&`) to their corresponding HTML-safe sequences.

The best way to fix the problem without changing existing functionality is to escape the `user_input` before appending it to the `template` string. This can be done by importing the `html` module and using the `html.escape()` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
