### PR TITLE
Fix code scanning alert no. 5: Reflected server-side cross-site scripting

### DIFF
--- a/src/vulnpy/django/vulnerable_asgi.py
+++ b/src/vulnpy/django/vulnerable_asgi.py
@@ -52,7 +52,8 @@ def get_trigger_view(name, trigger):
         template = get_template("{}.html".format(name))
 
         if name == "xss" and trigger == "raw":
-            template += "<p>XSS: " + user_input + "</p>"
+            import html
+            template += "<p>XSS: " + html.escape(user_input) + "</p>"
 
         return HttpResponse(template)
 


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Python_1/security/code-scanning/5](https://github.com/Brook-5686/Python_1/security/code-scanning/5)

To fix the reflected cross-site scripting vulnerability, we need to ensure that any user input included in the HTML response is properly escaped. This can be achieved by using the `html.escape()` function from the standard library, which safely escapes special characters in the input to prevent XSS attacks.

The best way to fix the problem without changing existing functionality is to apply `html.escape()` to the `user_input` variable before concatenating it into the HTML template string. This change should be made in the `get_trigger_view` function where the user input is processed and included in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
