### PR TITLE
Fix code scanning alert no. 4: Reflected server-side cross-site scripting

### DIFF
--- a/src/vulnpy/django/vulnerable.py
+++ b/src/vulnpy/django/vulnerable.py
@@ -33,7 +33,8 @@ def get_trigger_view(name, trigger):
         template = get_template("{}.html".format(name))
 
         if name == "xss" and trigger == "raw":
-            template += "<p>XSS: " + user_input + "</p>"
+            import html
+            template += "<p>XSS: " + html.escape(user_input) + "</p>"
 
         return HttpResponse(template)
 


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Python_1/security/code-scanning/4](https://github.com/Brook-5686/Python_1/security/code-scanning/4)

To fix the reflected cross-site scripting vulnerability, we need to ensure that any user input included in the HTML response is properly escaped. In this case, we can use the `html.escape` function from Python's standard library to escape the user input before including it in the HTML response.

The best way to fix the problem without changing existing functionality is to modify the code in the `get_trigger_view` function to escape the `user_input` before appending it to the `template`. This change should be made in the file `src/vulnpy/django/vulnerable.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
