### PR TITLE
Fix code scanning alert no. 3: Reflected server-side cross-site scripting

### DIFF
--- a/src/vulnpy/fastapi/vulnerable.py
+++ b/src/vulnpy/fastapi/vulnerable.py
@@ -4,6 +4,7 @@ from fastapi.responses import HTMLResponse
 from vulnpy.common import get_template
 
 from vulnpy.trigger import TRIGGER_MAP, get_trigger
+import html
 
 router = APIRouter()
 
@@ -39,7 +40,8 @@ def get_trigger_view(name, trigger):
         template = get_template("{}.html".format(name))
 
         if name == "xss" and trigger == "raw":
-            template += "<p>XSS: " + user_input + "</p>"
+            escaped_input = html.escape(user_input)
+            template += "<p>XSS: " + escaped_input + "</p>"
 
         return HTMLResponse(template)
 


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Python_1/security/code-scanning/3](https://github.com/Brook-5686/Python_1/security/code-scanning/3)

To fix the problem, we need to ensure that any user input included in the HTML response is properly escaped to prevent XSS attacks. The `html.escape()` function from Python's standard library can be used to escape special characters in the user input, making it safe to include in the HTML response.

The best way to fix the problem without changing existing functionality is to import the `html` module and use the `html.escape()` function to sanitize `user_input` before concatenating it into the `template`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
